### PR TITLE
Adicionando estrutura inicial para o pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+python_files = test.py tests.py test_*.py tests_*.py *_test.py *_tests.py
+filterwarnings =
+    ignore::DeprecationWarning

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ black==23.9.1
 blinker==1.6.2
 click==8.1.7
 dynaconf==3.2.2
+exceptiongroup==1.2.0
 Flask==2.3.3
 Flask-Cors==4.0.0
 Flask-Migrate==4.0.4
@@ -12,9 +13,10 @@ flask-restx==1.1.0
 Flask-SQLAlchemy==3.0.5
 greenlet==2.0.2
 gunicorn==21.2.0
+iniconfig==2.0.0
 itsdangerous==2.1.2
 Jinja2==3.1.2
-jsonschema==4.19.0
+jsonschema==4.21.1
 jsonschema-specifications==2023.7.1
 Mako==1.2.4
 MarkupSafe==2.1.3
@@ -23,7 +25,9 @@ mypy-extensions==1.0.0
 packaging==23.2
 pathspec==0.11.2
 platformdirs==3.11.0
+pluggy==1.4.0
 psycopg2-binary==2.9.9
+pytest==8.0.1
 python-dotenv==1.0.0
 pytz==2023.3.post1
 referencing==0.30.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import os
+
+import pytest
+
+from project import create_app_wsgi
+
+
+@pytest.fixture
+def app_testing():
+    os.environ['FLASK_ENV'] = 'testing'
+    return create_app_wsgi()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,17 @@
+import os
+
+from project import create_app_wsgi
+
+
+def test_app_name():
+    """Testa se o nome da aplicação 'project.base'"""
+    os.environ['FLASK_ENV'] = 'testing'
+    app = create_app_wsgi()
+    assert app.name == "project.base"
+
+
+def test_route_swagger_status_code_200(app_testing):
+    """Testa se o endpoint 'localhost:5000/api/v1/' retorna o status code 200"""
+    client = app_testing.test_client()
+    response = client.get('http://127.0.0.1:5000/api/v1/')
+    assert response.status_code == 200


### PR DESCRIPTION
DA-24
Adicionando estrutura (corrigindo a palavra) inicial para o Pytest na aplicação. Adicionado dois testes básicos que poderão ser mantidos durante a aplicação.

- Ambiente utilizado FLASK_ENV=testing 
- Comando para executar os testes:
    - pytest
    - pytest -v
 